### PR TITLE
Fix encode prefix

### DIFF
--- a/app/traffic-source-cookie.js
+++ b/app/traffic-source-cookie.js
@@ -35,7 +35,7 @@ var TrafficSourceCookie;
 
     encodeValue = function(value) {
       if (typeof window.btoa == 'function') {
-        return btoa(value);
+        return COOKIE_PREFIX + btoa(value);
       }
 
       return value;
@@ -121,7 +121,7 @@ var TrafficSourceCookie;
 
     generateCookie = function (acquisitionSource, conversionSource) {
       var cookieValue = conversionSource + COOKIE_TOKEN_SEPARATOR + acquisitionSource;
-      cookieValue = COOKIE_PREFIX + encodeValue(cookieValue);
+      cookieValue = encodeValue(cookieValue);
 
       setCookie(cookieValue);
     };


### PR DESCRIPTION
Fix an issue about browser that doesn't support `atob/btoa` functions.

This PR adds `encode_` prefix just when browser is able to encode the value. If this method is not supported, value will not be encoded and will not have the prefix.